### PR TITLE
tools: Preserve superblock between unpacking and re-packing

### DIFF
--- a/extract_blocks.py
+++ b/extract_blocks.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from fatx import FATX
+from fatx.blocks import SuperBlock
 
 if __name__ == "__main__":
     cwd = os.getcwd()
@@ -9,9 +10,9 @@ if __name__ == "__main__":
     os.mkdir(os.path.split(sys.argv[1])[1] + ".extract")
     os.chdir(os.path.split(sys.argv[1])[1] + ".extract")
     with open("superblock.bin", "w+b") as f:
-        f.write(fs.read(FATX.SUPERBLOCK_SIZE))
+        f.write(fs.read(SuperBlock.SUPERBLOCK_SIZE))
     with open("fat.bin", "w+b") as f:
-        fat_size = FATX.Filesystem._calc_fat_size(size)
+        fat_size = FATX.Filesystem._calc_fat_size(size, 512*32)
         f.write(fs.read(fat_size))
     for i in range(0, 10):
         with open("chunk({0}).bin".format(i), "w+b") as f:

--- a/fatx/FATX.py
+++ b/fatx/FATX.py
@@ -45,11 +45,15 @@ class Filesystem:
         self.root = RootObject(DirectoryEntryList(cluster, 1))
 
     @classmethod
-    def new(cls, size: int, file: str, sector_size: int = 512):
+    def new(cls, size: int, file: str, sector_size: int = 512, sb: bytes = None):
         self = cls.__new__(cls)
         self.f = open(file, "w+b")
 
-        self.sb = SuperBlock.new(sector_size)
+        if sb:
+            self.sb = SuperBlock(sb, sector_size)
+            print("Yupp found old superblock")
+        else:
+            self.sb = SuperBlock.new(sector_size)
         self.fat_size = self._calc_fat_size(size, self.sb.cluster_size)
         self.fat = FAT.new(self.fat_size)
         root_dl = DirectoryEntryList(b"\xFF" * 64, 1)

--- a/fatx/FATX.py
+++ b/fatx/FATX.py
@@ -51,7 +51,6 @@ class Filesystem:
 
         if sb:
             self.sb = SuperBlock(sb, sector_size)
-            print("Yupp found old superblock")
         else:
             self.sb = SuperBlock.new(sector_size)
         self.fat_size = self._calc_fat_size(size, self.sb.cluster_size)

--- a/unpack.py
+++ b/unpack.py
@@ -56,3 +56,10 @@ if __name__ == "__main__":
     root = fs.root
     os.chdir(dest)
     print("Unpacked {0} files.".format(walkfs(root)))
+    os.mkdir(".FATX-on-a-snake")
+    os.chdir(".FATX-on-a-snake")
+    f = open("superblock.bin", "wb")
+    f.write(fs.sb.pack())
+    f.close()
+    print("Saved superblock as {0}/{1}/{2}".format(
+        dest, ".FATX-on-a-snake", "superblock.bin"))


### PR DESCRIPTION
Addresses #13 
"Wörks" for now. Needs clean up. 

I'm not entirely happy with the solution I came up with but I didn't want to think even more about it, already wasted enough time without progress. The change is rather little so it wouldn't hurt that much, if this solution would be replaced/changed later.

What this basically does is:

- While unpacking an image, a copy of the superblock is written to `/dest/.FATX-on-a-snake/superblock.bin`
- When packing a folder into a new image, the source is checked if `/src/.FATX-on-a-snake/superblock.bin` exists, if so, it uses the given superblock. If not, it will create an empty one as usual.